### PR TITLE
FIX #76

### DIFF
--- a/spysmac/smacrun.py
+++ b/spysmac/smacrun.py
@@ -1,6 +1,8 @@
 import os
 import logging
+import shutil
 from contextlib import contextmanager
+from typing import Union
 
 from smac.facade.smac_facade import SMAC
 from smac.optimizer.objective import average_cost
@@ -24,7 +26,7 @@ class SMACrun(SMAC):
     SMACrun keeps all information on a specific SMAC run. Extends the standard
     SMAC-facade.
     """
-    def __init__(self, folder: str, ta_exec_dir: str="."):
+    def __init__(self, folder: str, ta_exec_dir: Union[str, None]=None):
         """Initialize scenario, runhistory and incumbent from folder, execute
         init-method of SMAC facade (so you could simply use SMAC-instances instead)
 
@@ -38,11 +40,18 @@ class SMACrun(SMAC):
             in the scenario-object. since instance- and PCS-files are necessary,
             specify the path to the execution-dir of SMAC here
         """
+        run_1_existed = os.path.exists('run_1')
         self.logger = logging.getLogger("spysmac.SMACrun.{}".format(folder))
         in_reader = InputReader()
 
         self.folder = folder
         self.logger.debug("Loading from %s", folder)
+
+        split_folder = os.path.split(folder)
+        if split_folder[0] and ta_exec_dir is None:
+            ta_exec_dir = split_folder[0]
+        elif ta_exec_dir is None:
+            ta_exec_dir = '.'
 
         self.scen_fn = os.path.join(folder, 'scenario.txt')
         self.rh_fn = os.path.join(folder, 'runhistory.json')
@@ -70,3 +79,5 @@ class SMACrun(SMAC):
                 #restore_incumbent=incumbent)
         # TODO use restore, delete next line
         self.solver.incumbent = incumbent
+        if (not run_1_existed) and os.path.exists('run_1'):
+            shutil.rmtree('run_1')

--- a/spysmac/spyfacade.py
+++ b/spysmac/spyfacade.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from typing import Union
 from collections import OrderedDict
 from contextlib import contextmanager
 import typing
@@ -54,7 +55,7 @@ class SpySMAC(object):
     """
 
     def __init__(self, folders: typing.List[str], output: str,
-                 ta_exec_dir: str='.', missing_data_method: str='epm'):
+                 ta_exec_dir: Union[str, None]=None, missing_data_method: str='epm'):
         """
         Initialize SpySMAC facade to handle analyzing, plotting and building the
         report-page easily. During initialization, the analysis-infrastructure
@@ -127,7 +128,7 @@ class SpySMAC(object):
 
         # Validator for a) validating with epm, b) plot over time
         # Initialize without trajectory
-        self.validator = Validator(self.scenario, None)
+        self.validator = Validator(self.scenario, None, None)
 
         # Estimate missing costs for [def, inc1, inc2, ...]
         self.complete_data(method=missing_data_method)
@@ -157,7 +158,7 @@ class SpySMAC(object):
         """Complete missing data of runs to be analyzed. Either using validation
         or EPM.
         """
-        with changedir(self.ta_exec_dir):
+        with changedir(self.ta_exec_dir if self.ta_exec_dir else '.'):
             self.logger.info("Completing data using %s.", method)
 
             path_for_validated_rhs = os.path.join(self.output, "validated_rhs")
@@ -408,7 +409,7 @@ class SpySMAC(object):
         # TODO feat-names from scenario?
         in_reader = InputReader()
         feat_fn = self.scenario.feature_fn
-        with changedir(self.ta_exec_dir):
+        with changedir(self.ta_exec_dir if self.ta_exec_dir else '.'):
             if not feat_fn or not os.path.exists(feat_fn):
                 self.logger.warning("Feature Analysis needs valid feature "
                                     "file! Either {} is not a valid "

--- a/spysmac/spyfacade.py
+++ b/spysmac/spyfacade.py
@@ -409,16 +409,19 @@ class SpySMAC(object):
         # TODO feat-names from scenario?
         in_reader = InputReader()
         feat_fn = self.scenario.feature_fn
-        with changedir(self.ta_exec_dir if self.ta_exec_dir else '.'):
-            if not feat_fn or not os.path.exists(feat_fn):
-                self.logger.warning("Feature Analysis needs valid feature "
-                                    "file! Either {} is not a valid "
-                                    "filename or features are not saved in "
-                                    "the scenario.")
-                self.logger.error("Skipping Feature Analysis.")
-                return
-            else:
-                feat_names = in_reader.read_instance_features_file(self.scenario.feature_fn)[0]
+        if not self.scenario.feature_names:
+            with changedir(self.ta_exec_dir if self.ta_exec_dir else '.'):
+                if not feat_fn or not os.path.exists(feat_fn):
+                    self.logger.warning("Feature Analysis needs valid feature "
+                                        "file! Either {} is not a valid "
+                                        "filename or features are not saved in "
+                                        "the scenario.")
+                    self.logger.error("Skipping Feature Analysis.")
+                    return
+                else:
+                    feat_names = in_reader.read_instance_features_file(self.scenario.feature_fn)[0]
+        else:
+            feat_names = self.scenario.feature_names
         fa = FeatureAnalysis(output_dn=self.output,
                              scenario=self.scenario,
                              feat_names=feat_names)

--- a/spysmac/spysmac_cli.py
+++ b/spysmac/spysmac_cli.py
@@ -49,7 +49,7 @@ class SpySMACCLI(object):
                                    "config/inst-pairs.")
         opt_opts.add_argument("--output", default="SpySMAC_output",
                               help="path to folder in which to save the HTML-report.")
-        opt_opts.add_argument("--ta_exec_dir", default='.',
+        opt_opts.add_argument("--ta_exec_dir", default=None,
                               help="path to the execution-directory of the "
                                    "SMAC run.")
         opt_opts.add_argument("--param_importance", default="all", nargs='+',


### PR DESCRIPTION
With this it is possible to read in smac output folders from different parent directories.

The checks if run_1 folder exists (and it's subsequent removal) is done as the latest SMAC version always generates output directory for a given run_id, even if the output_dir is set to ''.