### PR TITLE
ADD tqdm requirement as PIMP is using it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+tqdm
 Cython
 numpy
 pandas


### PR DESCRIPTION
Adds the new requirement stemming from PIMP.
In general, the requirements file should be reworked.
I'm aming to have a PIMP release on pypi befor Christmas. This should already improve the requirements file. Also we should use the newest SMAC release when it is out.